### PR TITLE
NONE - Fix nil transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2] - 2024-06-17
+
+### Fixed
+
+- Fixed the nil transform bug, which tended to happen if an object was deleted in close succession to another object
+
 ## [1.10.1] - 2024-06-17
 
 ### Fixed

--- a/packages/addon/lua/autorun/client/gelly-object-management.lua
+++ b/packages/addon/lua/autorun/client/gelly-object-management.lua
@@ -62,6 +62,12 @@ local function updateObject(entity)
 	local objectHandles = objects[entity]
 
 	for _, objectHandle in ipairs(objectHandles) do
+		if not IsValid(entity) then
+			-- Somehow, it got pass the entity removal check
+			removeObject(entity)
+			return
+		end
+
 		if entity == LocalPlayer() then
 			gelly.SetObjectPosition(objectHandle, entity:GetPos())
 			gelly.SetObjectRotation(objectHandle, Angle(90, 0, 0))
@@ -69,6 +75,15 @@ local function updateObject(entity)
 		end
 
 		local transform = entity:GetBoneMatrix(0)
+		if not transform then
+			transform = entity:GetWorldTransformMatrix()
+			if not transform then
+				logging.warn("Transform bug for entity #%d", entity:EntIndex())
+				removeObject(entity)
+				return
+			end
+		end
+
 		gelly.SetObjectPosition(objectHandle, transform:GetTranslation())
 		gelly.SetObjectRotation(objectHandle, transform:GetAngles())
 	end


### PR DESCRIPTION
## Ticket

<!-- The "Resolves" keyword will automatically close the issue when the PR is merged. -->
Resolves none

## Changes

- Fixes the nil transform bug
- Falls back on a world transform if bone transform returns nil
- Deletes the object if both are nil
