### PR TITLE
99 - Forcefields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The simulation scene now performs a dirty update when an object is removed.
+- Water preset is a tad more green
+
+### Fixed
+
+- Rendering/composition turns off when Gelly as a whole is inactive
 
 ## [1.12.2] - 2024-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The simulation scene now performs a dirty update when a object is removed.
+- The simulation scene now performs a dirty update when an object is removed.
 
 ## [1.12.2] - 2024-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - 2024-07-02
+
+### Added
+
+- Forcefield support in Gelly
+- New forcefield functions in Gelly API
+- A forcefield SENT and library in GellyX
+- Forcefields can be created with the Gelly Gun by holding the middle mouse button and pressing E.
+
+### Changed
+
+- The simulation scene now performs a dirty update when a object is removed.
+
 ## [1.12.2] - 2024-07-02
 
-### Changes
+### Changed
 
 - Changes the water preset to be more like the ocean, with a deep blue color.
 - Removes the thickness limit, which may appear a little weird but ultimately makes for far more realistic lighting.

--- a/packages/addon/lua/autorun/client/gelly-update-loop.lua
+++ b/packages/addon/lua/autorun/client/gelly-update-loop.lua
@@ -3,9 +3,13 @@ SIMULATE_GELLY = true
 
 local lastTimescale = GELLY_SIM_TIMESCALE
 
+local function isGellyActive()
+	return gelly.GetStatus().ActiveParticles > 0
+end
+
 hook.Add("GellyLoaded", "gelly.update-loop", function()
 	timer.Create("gelly.flex-update-timer", 1 / 60, 0, function()
-		if SIMULATE_GELLY then
+		if SIMULATE_GELLY and isGellyActive() then
 			if lastTimescale ~= GELLY_SIM_TIMESCALE then
 				lastTimescale = GELLY_SIM_TIMESCALE
 				gelly.SetTimeStepMultiplier(GELLY_SIM_TIMESCALE)
@@ -16,10 +20,12 @@ hook.Add("GellyLoaded", "gelly.update-loop", function()
 	end)
 
 	hook.Add("RenderScene", "gelly.render", function()
+		if not isGellyActive() then return end
 		gelly.Render()
 	end)
 
 	hook.Add("PostDrawOpaqueRenderables", "gelly.composite", function()
+		if not isGellyActive() then return end
 		gelly.Composite()
 	end)
 end)

--- a/packages/addon/lua/entities/gellyx_forcefield.lua
+++ b/packages/addon/lua/entities/gellyx_forcefield.lua
@@ -12,7 +12,14 @@ AccessorFunc(ENT, "Strength", "Strength", FORCE_NUMBER)
 AccessorFunc(ENT, "LinearFalloff", "LinearFalloff", FORCE_BOOL)
 AccessorFunc(ENT, "Mode", "Mode", FORCE_NUMBER) -- type is actually gellyx.forcefield.Mode
 
+function ENT:UpdateTransmitState()
+	return TRANSMIT_ALWAYS
+end
+
 function ENT:Initialize()
+	self:SetModel("models/props_junk/PopCan01a.mdl")
+	self:SetNoDraw(true)
+
 	if CLIENT then
 		self.ForcefieldHandle = gelly.AddForcefieldObject({
 			Position = Vector(),

--- a/packages/addon/lua/entities/gellyx_forcefield.lua
+++ b/packages/addon/lua/entities/gellyx_forcefield.lua
@@ -1,0 +1,48 @@
+AddCSLuaFile()
+
+ENT.Base = "base_anim"
+ENT.Type = "anim"
+ENT.Category = "GellyX"
+ENT.PrintName = "GellyX Forcefield"
+ENT.Spawnable = false
+ENT.AdminOnly = false
+
+AccessorFunc(ENT, "Radius", "Radius", FORCE_NUMBER)
+AccessorFunc(ENT, "Strength", "Strength", FORCE_NUMBER)
+AccessorFunc(ENT, "LinearFalloff", "LinearFalloff", FORCE_BOOL)
+AccessorFunc(ENT, "Mode", "Mode", FORCE_NUMBER) -- type is actually gellyx.forcefield.Mode
+
+function ENT:Initialize()
+	if CLIENT then
+		self.ForcefieldHandle = gelly.AddForcefieldObject({
+			Position = Vector(),
+			Radius = self.Radius,
+			Strength = self.Strength,
+			LinearFalloff = self.LinearFalloff,
+			Mode = self.Mode,
+		})
+
+		self:SetNextClientThink(CurTime())
+	end
+end
+
+function ENT:Think()
+	if SERVER then
+		return
+	end
+
+	if self.ForcefieldHandle then
+		gelly.UpdateForcefieldPosition(self.ForcefieldHandle, self:GetPos())
+	end
+
+	self:SetNextClientThink(CurTime() + 0.01)
+	return true
+end
+
+function ENT:OnRemove()
+	if CLIENT then
+		if self.ForcefieldHandle then
+			gelly.RemoveForcefieldObject(self.ForcefieldHandle)
+		end
+	end
+end

--- a/packages/addon/lua/gelly/api/gx-forcefields.lua
+++ b/packages/addon/lua/gelly/api/gx-forcefields.lua
@@ -1,0 +1,30 @@
+gellyx = gellyx or {}
+gellyx.forcefield = gellyx.forcefield or {}
+
+---@enum gellyx.forcefield.Mode
+gellyx.forcefield.Mode = {
+	Force = 0,
+	Impulse = 1,
+	VelocityChange = 2,
+}
+
+---@alias gellyx.forcefield.Params {Position: Vector, Radius: number, Strength: number, LinearFalloff: boolean, Mode: gellyx.forcefield.Mode}
+
+--- Creates a new forcefield. They're implemented as SENTs for semantic reasons, so feel free to use them as such. There should be no burden to properly remove them, as they're automatically removed when the entity is removed.
+---@param params gellyx.forcefield.Params
+---@return Entity|nil The created forcefield entity
+function gellyx.forcefield.create(params)
+	local ent = ents.CreateClientside("gellyx_forcefield")
+	if not IsValid(ent) then
+		return nil
+	end
+
+	ent:SetPos(params.Position)
+	ent:SetRadius(params.Radius)
+	ent:SetStrength(params.Strength)
+	ent:SetLinearFalloff(params.LinearFalloff)
+	ent:SetMode(params.Mode)
+	ent:Spawn()
+
+	return ent
+end

--- a/packages/addon/lua/gelly/api/gx-init.lua
+++ b/packages/addon/lua/gelly/api/gx-init.lua
@@ -1,5 +1,5 @@
 include("gx-soft-functions.lua")
-
+include("gx-forcefields.lua")
 include("gx-fluid-presets.lua")
 gellyx.presets.loadPresetFiles()
 

--- a/packages/addon/lua/gelly/api/presets/immutable/water.lua
+++ b/packages/addon/lua/gelly/api/presets/immutable/water.lua
@@ -14,7 +14,7 @@ return {
 		Roughness = 0,
 		IsSpecularTransmission = true,
 		RefractiveIndex = 1.333,
-		Absorption = Vector(0.1, 0.04, 0.02),
+		Absorption = Vector(0.1, 0.03, 0.02),
 		DiffuseColor = Vector(0, 0, 0),
 	},
 }

--- a/packages/addon/lua/weapons/gelly_gun.lua
+++ b/packages/addon/lua/weapons/gelly_gun.lua
@@ -56,9 +56,11 @@ end
 
 function SWEP:OnGrabberKeyPressed()
 	if self.Forcefield then
+		surface.PlaySound("buttons/button10.wav")
 		self.Forcefield:Remove()
 		self.Forcefield = nil
 	else
+		surface.PlaySound("buttons/button9.wav")
 		self.Forcefield = gellyx.forcefield.create({
 			Position = self:GetOwner():GetShootPos(),
 			Radius = 100,

--- a/packages/addon/lua/weapons/gelly_gun.lua
+++ b/packages/addon/lua/weapons/gelly_gun.lua
@@ -45,6 +45,28 @@ function SWEP:PrimaryAttack()
 		return
 	end
 
+	if input.IsKeyDown(KEY_X) then
+		-- enable our grabber tool
+		local isGrabberEnabled = self.Forcefield ~= nil
+		if not isGrabberEnabled then
+			self.Forcefield = gellyx.forcefield.create({
+				Position = self:GetOwner():GetShootPos(),
+				Radius = 50,
+				Strength = -1000,
+				LinearFalloff = false,
+				Mode = gellyx.forcefield.Mode.Force,
+			})
+
+			self.ForcefieldDistance = self:GetOwner():GetEyeTrace().HitPos:Distance(self:GetOwner():GetShootPos())
+		else
+			self.Forcefield:SetPos(self:GetOwner():GetShootPos() +
+				self:GetOwner():GetAimVector() * self.ForcefieldDistance)
+		end
+	elseif self.Forcefield then
+		self.Forcefield:Remove()
+		self.Forcefield = nil
+	end
+
 	---@type Player
 	local owner = self:GetOwner()
 

--- a/packages/addon/lua/weapons/gelly_gun.lua
+++ b/packages/addon/lua/weapons/gelly_gun.lua
@@ -48,7 +48,6 @@ function SWEP:InitializeGrabberHooks()
 	end
 
 	hook.Add("KeyPress", self, function(_, ply, key)
-		print(key)
 		if key == GRABBER_KEY and not self:IsInputBlocked() and self:GetOwner():GetActiveWeapon() == self and input.IsButtonDown(MOUSE_MIDDLE) then
 			self:OnGrabberKeyPressed()
 		end
@@ -63,9 +62,9 @@ function SWEP:OnGrabberKeyPressed()
 		self.Forcefield = gellyx.forcefield.create({
 			Position = self:GetOwner():GetShootPos(),
 			Radius = 100,
-			Strength = -1000,
-			LinearFalloff = false,
-			Mode = gellyx.forcefield.Mode.Force,
+			Strength = -2000,
+			LinearFalloff = true,
+			Mode = gellyx.forcefield.Mode.Impulse,
 		})
 
 		self.ForcefieldDistance = self:GetOwner():GetEyeTrace().HitPos:Distance(self:GetOwner():GetShootPos())

--- a/packages/addon/lua/weapons/gelly_gun.lua
+++ b/packages/addon/lua/weapons/gelly_gun.lua
@@ -64,9 +64,9 @@ function SWEP:OnGrabberKeyPressed()
 		self.Forcefield = gellyx.forcefield.create({
 			Position = self:GetOwner():GetShootPos(),
 			Radius = 100,
-			Strength = -2000,
-			LinearFalloff = true,
-			Mode = gellyx.forcefield.Mode.Impulse,
+			Strength = -100,
+			LinearFalloff = false,
+			Mode = gellyx.forcefield.Mode.Force,
 		})
 
 		self.ForcefieldDistance = self:GetOwner():GetEyeTrace().HitPos:Distance(self:GetOwner():GetShootPos())

--- a/packages/gelly-gmod/CMakeLists.txt
+++ b/packages/gelly-gmod/CMakeLists.txt
@@ -95,6 +95,7 @@ add_library(
         src/exceptions/get-stack-size.cpp
         src/exceptions/get-stack-size.h
         src/version.h.in
+        src/util/lua-table.h
 )
 
 # Propagate GELLY_ENABLE_RENDERDOC_CAPTURES down to compile definitions

--- a/packages/gelly-gmod/src/main.cpp
+++ b/packages/gelly-gmod/src/main.cpp
@@ -328,7 +328,7 @@ LUA_FUNCTION(gelly_AddForcefieldObject) {
 	const float radius = luaTable.Get("Radius", 0.f);
 	const float strength = luaTable.Get("Strength", 0.f);
 	const bool linearFalloff = luaTable.Get("LinearFalloff", false);
-	const NvFlexExtForceMode mode =
+	const int mode =
 		luaTable.Get("Mode", NvFlexExtForceMode::eNvFlexExtModeForce);
 
 	ObjectCreationParams forcefield = {};
@@ -337,7 +337,7 @@ LUA_FUNCTION(gelly_AddForcefieldObject) {
 		.position = {position.x, position.y, position.z},
 		.radius = radius,
 		.strength = strength,
-		.mode = mode,
+		.mode = static_cast<NvFlexExtForceMode>(mode),
 		.linearFalloff = linearFalloff
 	};
 

--- a/packages/gelly-gmod/src/scene/Scene.h
+++ b/packages/gelly-gmod/src/scene/Scene.h
@@ -57,6 +57,22 @@ public:
 	void SetFluidProperties(const SetFluidProperties &props) const;
 	void ChangeRadius(float radius) const;
 
+	[[nodiscard]] ObjectHandle AddForcefield(
+		const ObjectCreationParams &forcefield
+	) {
+		return sim->GetScene()->CreateObject(forcefield);
+	}
+
+	void UpdateForcefieldPosition(ObjectHandle handle, const Vector &position) {
+		sim->GetScene()->SetObjectPosition(
+			handle, position.x, position.y, position.z
+		);
+	}
+
+	void RemoveForcefield(ObjectHandle handle) {
+		sim->GetScene()->RemoveObject(handle);
+	}
+
 	[[nodiscard]] int GetActiveParticles() const {
 		return sim->GetSimulationData()->GetActiveParticles();
 	}

--- a/packages/gelly-gmod/src/util/lua-table.h
+++ b/packages/gelly-gmod/src/util/lua-table.h
@@ -21,13 +21,17 @@ public:
 	template <typename T>
 	auto Get(const char *key, T defaultValue) const -> T {
 		lua->GetField(-1, key);
-		return FetchFromStack<T>(-1).value_or(defaultValue);
+		auto value = FetchFromStack<T>(-1).value_or(defaultValue);
+		lua->Pop();
+		return value;
 	}
 
 	template <typename T>
 	auto Get(const char *key) const -> std::optional<T> {
 		lua->GetField(-1, key);
-		return FetchFromStack<T>(-1);
+		auto value = FetchFromStack<T>(-1);
+		lua->Pop();
+		return value;
 	}
 
 private:
@@ -43,7 +47,7 @@ private:
 
 		if constexpr (std::is_same_v<T, bool>) {
 			return static_cast<T>(lua->GetBool(index));
-		} else if constexpr (std::is_same_v<T, double>) {
+		} else if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float> || std::is_same_v<T, int>) {
 			return static_cast<T>(lua->GetNumber(index));
 		} else if constexpr (std::is_same_v<T, const char *>) {
 			return static_cast<T>(lua->GetString(index));
@@ -58,7 +62,7 @@ private:
 	[[nodiscard]] auto InferType() const noexcept -> GModType {
 		if constexpr (std::is_same_v<T, bool>) {
 			return GarrysMod::Lua::Type::Bool;
-		} else if constexpr (std::is_same_v<T, double>) {
+		} else if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float> || std::is_same_v<T, int>) {
 			return GarrysMod::Lua::Type::Number;
 		} else if constexpr (std::is_same_v<T, const char *>) {
 			return GarrysMod::Lua::Type::String;

--- a/packages/gelly-gmod/src/util/lua-table.h
+++ b/packages/gelly-gmod/src/util/lua-table.h
@@ -1,0 +1,77 @@
+#ifndef LUA_TABLE_H
+#define LUA_TABLE_H
+#include <optional>
+
+#include "GarrysMod/Lua/LuaBase.h"
+
+namespace gelly {
+namespace gmod {
+namespace helpers {
+
+using GModType = decltype(GarrysMod::Lua::Type::None);
+
+class LuaTable {
+public:
+	explicit LuaTable(GarrysMod::Lua::ILuaBase *lua) : lua(lua) {}
+
+	[[nodiscard]] auto GetLength() const noexcept -> int {
+		return lua->ObjLen(-1);
+	}
+
+	template <typename T>
+	auto Get(const char *key, T defaultValue) const -> T {
+		lua->GetField(-1, key);
+		return FetchFromStack<T>(-1).value_or(defaultValue);
+	}
+
+	template <typename T>
+	auto Get(const char *key) const -> std::optional<T> {
+		lua->GetField(-1, key);
+		return FetchFromStack<T>(-1);
+	}
+
+private:
+	GarrysMod::Lua::ILuaBase *lua = nullptr;
+
+	template <typename T>
+	auto FetchFromStack(const int index) const noexcept -> std::optional<T> {
+		const auto stackValueType = lua->GetType(index);
+		if (const auto expectedType = InferType<T>();
+			stackValueType != expectedType) {
+			return std::nullopt;
+		}
+
+		if constexpr (std::is_same_v<T, bool>) {
+			return static_cast<T>(lua->GetBool(index));
+		} else if constexpr (std::is_same_v<T, double>) {
+			return static_cast<T>(lua->GetNumber(index));
+		} else if constexpr (std::is_same_v<T, const char *>) {
+			return static_cast<T>(lua->GetString(index));
+		} else if constexpr (std::is_same_v<T, Vector>) {
+			return lua->GetVector(index);
+		} else {
+			return std::nullopt;
+		}
+	}
+
+	template <typename T>
+	[[nodiscard]] auto InferType() const noexcept -> GModType {
+		if constexpr (std::is_same_v<T, bool>) {
+			return GarrysMod::Lua::Type::Bool;
+		} else if constexpr (std::is_same_v<T, double>) {
+			return GarrysMod::Lua::Type::Number;
+		} else if constexpr (std::is_same_v<T, const char *>) {
+			return GarrysMod::Lua::Type::String;
+		} else if constexpr (std::is_same_v<T, Vector>) {
+			return GarrysMod::Lua::Type::Vector;
+		} else {
+			return GarrysMod::Lua::Type::None;
+		}
+	}
+};
+
+}  // namespace helpers
+}  // namespace gmod
+}  // namespace gelly
+
+#endif	// LUA_TABLE_H

--- a/packages/gelly/modules/gelly-fluid-sim/include/fluidsim/CFlexSimScene.h
+++ b/packages/gelly/modules/gelly-fluid-sim/include/fluidsim/CFlexSimScene.h
@@ -26,7 +26,9 @@ struct ObjectData {
 	float rotation[4]{};
 	bool firstFrame = true;
 
-	std::variant<TriangleMesh, Capsule> shapeData;
+	std::variant<TriangleMesh, Capsule, ObjectCreationParams::Forcefield>
+		shapeData;
+
 	uint currentShapeIndex{};
 };
 
@@ -39,6 +41,7 @@ private:
 
 	NvFlexLibrary *library = nullptr;
 	NvFlexSolver *solver = nullptr;
+	NvFlexExtForceFieldCallback *forceFieldCallback = nullptr;
 
 	struct {
 		NvFlexBuffer *positions;
@@ -61,6 +64,10 @@ private:
 
 	[[nodiscard]] ObjectData CreateCapsule(
 		const ObjectCreationParams::Capsule &params
+	) const;
+
+	[[nodiscard]] ObjectData CreateForcefield(
+		const ObjectCreationParams::Forcefield &params
 	) const;
 
 public:

--- a/packages/gelly/modules/gelly-fluid-sim/include/fluidsim/ISimScene.h
+++ b/packages/gelly/modules/gelly-fluid-sim/include/fluidsim/ISimScene.h
@@ -6,6 +6,7 @@
 #include <variant>
 
 #include "GellyDataTypes.h"
+#include "NvFlexExt.h"
 
 using namespace Gelly::DataTypes;
 
@@ -13,6 +14,7 @@ namespace Gelly {
 enum class ObjectShape : uint8_t {
 	TRIANGLE_MESH,
 	CAPSULE,
+	FORCEFIELD,
 };
 
 struct ObjectCreationParams {
@@ -46,8 +48,20 @@ struct ObjectCreationParams {
 		float halfHeight;
 	};
 
+	/**
+	 * Forcefields aren't physical objects, so any calls which don't make sense
+	 * (like setting its rotation) *is* ok and will be ignored.
+	 */
+	struct Forcefield {
+		float position[3];
+		float radius;
+		float strength;
+		NvFlexExtForceMode mode;
+		bool linearFalloff;
+	};
+
 	ObjectShape shape = ObjectShape::TRIANGLE_MESH;
-	std::variant<TriangleMesh, Capsule> shapeData;
+	std::variant<TriangleMesh, Capsule, Forcefield> shapeData;
 };
 
 using ObjectHandle = uint;

--- a/packages/gelly/modules/gelly-fluid-sim/src/fluidsim/CFlexSImScene.cpp
+++ b/packages/gelly/modules/gelly-fluid-sim/src/fluidsim/CFlexSImScene.cpp
@@ -82,6 +82,7 @@ CFlexSimScene::~CFlexSimScene() {
 	NvFlexFreeBuffer(geometry.prevRotations);
 	NvFlexFreeBuffer(geometry.info);
 	NvFlexFreeBuffer(geometry.flags);
+	NvFlexExtDestroyForceFieldCallback(forceFieldCallback);
 }
 
 ObjectHandle CFlexSimScene::CreateObject(const ObjectCreationParams &params) {

--- a/packages/gelly/modules/gelly-fluid-sim/src/fluidsim/CFlexSImScene.cpp
+++ b/packages/gelly/modules/gelly-fluid-sim/src/fluidsim/CFlexSImScene.cpp
@@ -426,6 +426,26 @@ ObjectData CFlexSimScene::CreateCapsule(
 	return data;
 }
 
+ObjectData CFlexSimScene::CreateForcefield(
+	const ObjectCreationParams::Forcefield &params
+) const {
+	ObjectData data = {};
+
+	data.shape = ObjectShape::FORCEFIELD;
+
+	data.position[0] = 0.0f;
+	data.position[1] = 0.0f;
+	data.position[2] = 0.0f;
+
+	data.rotation[0] = 0.0f;
+	data.rotation[1] = 0.0f;
+	data.rotation[2] = 0.0f;
+	data.rotation[3] = 1.0f;
+
+	data.shapeData = params;
+	return data;
+}
+
 ObjectHandle CFlexSimScene::GetHandleFromShapeIndex(const uint &shapeIndex) {
 	const auto it = std::find_if(
 		objects.begin(),

--- a/packages/gelly/modules/gelly-fluid-sim/src/fluidsim/CFlexSImScene.cpp
+++ b/packages/gelly/modules/gelly-fluid-sim/src/fluidsim/CFlexSImScene.cpp
@@ -137,6 +137,7 @@ void CFlexSimScene::RemoveObject(ObjectHandle handle) {
 	}
 
 	objects.erase(object);
+	dirty = true;
 }
 
 void CFlexSimScene::SetObjectPosition(


### PR DESCRIPTION
## Ticket

<!-- The "Resolves" keyword will automatically close the issue when the PR is merged. -->
Resolves #99 

## Changes

- Adds forcefields to Gelly
- Exposes forcefields as another object in ISimScene
- Exposes forcefield manipulation to the Gelly Lua API
- Exposes forcefields as SENTs in GellyX
- Adds a forcefield library to GellyX
- Makes the Gelly Gun use a forcefield mode to grab fluid (bind: middle mouse button + e)
- Improves the water absorption
- Fixes compositing not turning off when no particles are active
- Adds a new helper, `LuaTable`, for manipulating table-based configuration functions

