### PR TITLE
NONE - Increase kernel footprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2024-07-13
+
+### Changed
+
+- Added pixel-size invariant rendering, which means the fluid will remain smooth no matter how close or far away you are
+  from it.
+
+### Fixed
+
+- Fixed normals becoming a little biased in the last surface filter update.
+
 ## [1.16.0] - 2024-07-12
 
 ### Added

--- a/packages/gelly-gmod/src/composite/standard/StandardTextures.cpp
+++ b/packages/gelly-gmod/src/composite/standard/StandardTextures.cpp
@@ -3,7 +3,7 @@
 #include <utility>
 
 std::pair<ComPtr<IDirect3DTexture9>, HANDLE> StandardTextures::CreateTexture(
-	const char *name, D3DFORMAT format
+	const char *name, D3DFORMAT format, int levels
 ) const {
 	HANDLE sharedHandle = nullptr;
 	ComPtr<IDirect3DTexture9> gmodTexture;
@@ -11,7 +11,7 @@ std::pair<ComPtr<IDirect3DTexture9>, HANDLE> StandardTextures::CreateTexture(
 	if (FAILED(gmodResources.device->CreateTexture(
 			width,
 			height,
-			1,
+			levels,
 			D3DUSAGE_RENDERTARGET,
 			format,
 			D3DPOOL_DEFAULT,

--- a/packages/gelly-gmod/src/composite/standard/StandardTextures.h
+++ b/packages/gelly-gmod/src/composite/standard/StandardTextures.h
@@ -21,7 +21,7 @@ private:
 	unsigned int height;
 
 	std::pair<ComPtr<IDirect3DTexture9>, HANDLE> CreateTexture(
-		const char *name, D3DFORMAT format
+		const char *name, D3DFORMAT format, int levels = 1
 	) const;
 
 	void CreateFeatureTextures();

--- a/packages/gelly/modules/gelly-fluid-renderer/src/shaders/FilterDepth.ps50.hlsl
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/shaders/FilterDepth.ps50.hlsl
@@ -10,7 +10,7 @@ Texture2D InputNormal : register(t1);
 SamplerState InputNormalSampler : register(s1);
 
 static const float INVALID_EYE_DEPTH_EPSILON = 0.001f;
-static const float RETAINMENT_PERCENTAGE = 0.5f; // retain 50% of last generation's normal
+static const float RETAINMENT_PERCENTAGE = 1.f; // retain 50% of last generation's normal
 static const float NORMAL_MIP_LEVEL = 8.f;
 
 struct PS_OUTPUT {

--- a/packages/gelly/modules/gelly-fluid-renderer/src/shaders/FilterDepth.ps50.hlsl
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/shaders/FilterDepth.ps50.hlsl
@@ -10,7 +10,6 @@ Texture2D InputNormal : register(t1);
 SamplerState InputNormalSampler : register(s1);
 
 static const float INVALID_EYE_DEPTH_EPSILON = 0.001f;
-static const float RETAINMENT_PERCENTAGE = 1.f; // retain 50% of last generation's normal
 static const float NORMAL_MIP_LEVEL = 8.f;
 
 struct PS_OUTPUT {
@@ -122,7 +121,6 @@ float3 CreateIsosurfaceNormals(float2 tex) {
     }
 
     normal = normalize(normal);
-    normal = lerp(normalTaps[4], normal, RETAINMENT_PERCENTAGE);
     return normal;
 }
 

--- a/packages/gelly/modules/gelly-fluid-renderer/src/shaders/FilterDepth.ps50.hlsl
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/shaders/FilterDepth.ps50.hlsl
@@ -11,6 +11,7 @@ SamplerState InputNormalSampler : register(s1);
 
 static const float INVALID_EYE_DEPTH_EPSILON = 0.001f;
 static const float RETAINMENT_PERCENTAGE = 0.5f; // retain 50% of last generation's normal
+static const float NORMAL_MIP_LEVEL = 8.f;
 
 struct PS_OUTPUT {
     float4 FilteredNormal : SV_Target0;
@@ -22,8 +23,16 @@ float FetchEyeDepth(float2 pixel) {
 	return sign(eyeDepth) == -1.f ? eyeDepth : -eyeDepth;
 }
 
-float3 FetchNormal(float2 pixel) {
-    return InputNormal.SampleLevel(InputNormalSampler, pixel / float2(g_ViewportWidth, g_ViewportHeight), 0).xyz;
+float3 FetchNormal(float2 pixel, float eyeDepth) {
+	// In order to increase our kernel's footprint cheaply, we can compute the size of the pixel in world space to determine the mip level to sample from
+	// This is a cheap way to increase the kernel's footprint without having to do any expensive calculations
+	// Anyways, to facilitate this we could accurately unproject the pixel and calculate something something derivative, but that's expensive
+
+	float mipLevel = 8 - 1.3f * log2((0.2f * abs(eyeDepth)) + 0.0001f);
+	mipLevel = clamp(mipLevel, 0, NORMAL_MIP_LEVEL);
+
+	float2 uv = pixel / float2(g_ViewportWidth, g_ViewportHeight);
+    return InputNormal.SampleLevel(InputNormalSampler, uv, mipLevel).xyz;
 }
 
 inline bool IsDepthInvalid(float depth) {
@@ -54,18 +63,6 @@ float3 CreateIsosurfaceNormals(float2 tex) {
 	be considered otherwise.
     */
 
-    float3 normalTaps[9] = {
-        FetchNormal(centerPixel + float2(-1, -1)),
-        FetchNormal(centerPixel + float2( 0, -1)),
-        FetchNormal(centerPixel + float2( 1, -1)),
-        FetchNormal(centerPixel + float2(-1,  0)),
-        FetchNormal(centerPixel + float2( 0,  0)),
-        FetchNormal(centerPixel + float2( 1,  0)),
-        FetchNormal(centerPixel + float2(-1,  1)),
-        FetchNormal(centerPixel + float2( 0,  1)),
-        FetchNormal(centerPixel + float2( 1,  1))
-    };
-
     float kernel[9] = {
         FetchEyeDepth(centerPixel + float2(-1, -1)),
         FetchEyeDepth(centerPixel + float2( 0, -1)),
@@ -77,15 +74,24 @@ float3 CreateIsosurfaceNormals(float2 tex) {
         FetchEyeDepth(centerPixel + float2( 0,  1)),
         FetchEyeDepth(centerPixel + float2( 1,  1))
     };
+	
+    float3 normalTaps[9] = {
+        FetchNormal(centerPixel + float2(-1, -1), kernel[0]),
+        FetchNormal(centerPixel + float2( 0, -1), kernel[1]),
+        FetchNormal(centerPixel + float2( 1, -1), kernel[2]),
+        FetchNormal(centerPixel + float2(-1,  0), kernel[3]),
+        FetchNormal(centerPixel + float2( 0,  0), kernel[4]),
+        FetchNormal(centerPixel + float2( 1,  0), kernel[5]),
+        FetchNormal(centerPixel + float2(-1,  1), kernel[6]),
+        FetchNormal(centerPixel + float2( 0,  1), kernel[7]),
+        FetchNormal(centerPixel + float2( 1,  1), kernel[8])
+    };
 
     [unroll]
     for (int i = 0; i < 9; i++) {
         // our pipeline initializes every invalid depth to D3D11_FLOAT32_MAX so this is how we can check for invalid depth
-        if (IsDepthInvalid(kernel[i])) {
-            kernel[i] = kernel[4]; // center pixel
-            // technically, this isn't symmetric, but it's close enough and makes for a nicer visual result. Plus, it's faster.
-            kernel[9 - i] = kernel[4]; // center pixel
-        }
+        // fun thing is that we don't actually need to even have a special case for this, as the normal will be discarded anyway
+		// since FLOAT32_MAX - <average depth> is always going to be a large number, and it will just be discarded by the kernel
 
         if (IsNormalAllZero(normalTaps[i]) || IsNormalAllOne(normalTaps[i])) {
             kernel[i] = 0.f; // discard this kernel value if the normal is invalid
@@ -99,8 +105,14 @@ float3 CreateIsosurfaceNormals(float2 tex) {
             continue;
         }
 
-        kernel[j] /= centerKernel; // normalize the kernel
-        kernel[j] *= 1 / 9.f;
+		kernel[j] = abs(kernel[j] - centerKernel) * 20.f;
+		// scale the difference to be between 0 and 1
+		kernel[j] /= -centerKernel; // flip since we're in negative space
+		kernel[j] = saturate(kernel[j]);
+
+		// invert the value so that the maximum value is 1 (which semantically means that the closer the value is to 1, the more we want to retain it)
+		kernel[j] = 1.f - kernel[j];
+        kernel[j] *= 1 / 9.f; // keep the sum of the kernel to 1 to avoid biasing the normal
     }
 
     float3 normal = float3(0, 0, 0);
@@ -132,7 +144,7 @@ PS_OUTPUT main(VS_OUTPUT input) {
     float3 normal = CreateIsosurfaceNormals(input.Tex);
     if (isnan(normal.x) || isnan(normal.y) || isnan(normal.z)) {
         // return the original normal if the new one is invalid
-        normal = FetchNormal(input.Tex);
+        normal = InputNormal.SampleLevel(InputNormalSampler, input.Tex, 0).xyz;
         output.FilteredNormal = float4(normal, 1.f);
         return output;
     }

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/pipeline/pipeline.cpp
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/pipeline/pipeline.cpp
@@ -50,6 +50,7 @@ auto Pipeline::Run(const std::optional<int> vertexCount) -> void {
 		);
 	}
 
+	UpdateMipsForMipmappedTextures();
 	SetupRenderPass();
 	SetupInputAssembler();
 	SetupOutputMerger();
@@ -213,6 +214,28 @@ auto Pipeline::SetupShaderStages() -> void {
 		const auto *inputBuffer = std::get_if<InputBuffer>(&input);
 		if (inputBuffer) {
 			BindInputBuffer(deviceContext, *inputBuffer);
+		}
+	}
+}
+
+auto Pipeline::UpdateMipsForMipmappedTextures() -> void {
+	auto *deviceContext = createInfo.device->GetRawDeviceContext().Get();
+
+	for (const auto &output : createInfo.outputs) {
+		const auto *outputTexture = std::get_if<OutputTexture>(&output);
+		if (outputTexture && outputTexture->texture->GetMipLevels() > 1) {
+			deviceContext->GenerateMips(
+				outputTexture->texture->GetShaderResourceView().Get()
+			);
+		}
+	}
+
+	for (const auto &input : createInfo.inputs) {
+		const auto *inputTexture = std::get_if<InputTexture>(&input);
+		if (inputTexture && inputTexture->texture->GetMipLevels() > 1) {
+			deviceContext->GenerateMips(
+				inputTexture->texture->GetShaderResourceView().Get()
+			);
 		}
 	}
 }

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/pipeline/pipeline.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/pipeline/pipeline.h
@@ -64,6 +64,7 @@ private:
 	auto SetupInputAssembler() -> void;
 	auto SetupOutputMerger() -> void;
 	auto SetupShaderStages() -> void;
+	auto UpdateMipsForMipmappedTextures() -> void;
 
 	static auto BindInputTexture(
 		const ComPtr<ID3D11DeviceContext> &deviceContext,

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/texture-registry.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/texture-registry.h
@@ -193,7 +193,9 @@ struct InternalTextures {
 				  .cpuAccessFlags = 0,
 				  .miscFlags = 0,
 				  .arraySize = 1,
-				  .mipLevels = 1,
+				  .mipLevels = 8,  // we want to have mips so that in some
+								   // cases, we can increase a kernel footprint
+								   // without having to use more iterations
 				  .name = "Unfiltered Normals"}
 			 ),
 			 .bindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET}

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/resources/native-image.cpp
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/resources/native-image.cpp
@@ -34,6 +34,10 @@ auto NativeImage::CreateTexture2D() -> ComPtr<ID3D11Texture2D> {
 	desc.CPUAccessFlags = createInfo.cpuAccessFlags;
 	desc.MiscFlags = createInfo.miscFlags;
 
+	if (createInfo.mipLevels > 1) {
+		desc.MiscFlags |= D3D11_RESOURCE_MISC_GENERATE_MIPS;
+	}
+
 	ComPtr<ID3D11Texture2D> texture;
 	const auto result = createInfo.device->GetRawDevice()->CreateTexture2D(
 		&desc, nullptr, &texture

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/resources/texture.cpp
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/resources/texture.cpp
@@ -57,6 +57,10 @@ auto Texture::GetFormat() -> DXGI_FORMAT {
 	return createInfo.format.value_or(createInfo.image->GetFormat());
 }
 
+auto Texture::GetMipLevels() -> UINT {
+	return createInfo.image->GetMipLevels();
+}
+
 auto Texture::CreateRenderTargetView(const ComPtr<ID3D11Texture2D> &texture)
 	-> ComPtr<ID3D11RenderTargetView> {
 	D3D11_RENDER_TARGET_VIEW_DESC desc = {};

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/resources/texture.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/resources/texture.h
@@ -36,6 +36,7 @@ public:
 	auto GetUnorderedAccessView() -> ComPtr<ID3D11UnorderedAccessView>;
 	auto GetSamplerState() -> ComPtr<ID3D11SamplerState>;
 	auto GetFormat() -> DXGI_FORMAT;
+	auto GetMipLevels() -> UINT;
 
 private:
 	TextureCreateInfo createInfo;


### PR DESCRIPTION
## Ticket

<!-- The "Resolves" keyword will automatically close the issue when the PR is merged. -->
Resolves none

## Changes

- Adds depth-based mip selection, effectively increasing our kernel footprint to create smoother surfaces
- Removes the biased retainment method

