### PR TITLE
Added clearing command and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.3] - 2024-08-26
+
+### Added
+
+- Added a console command to clear particles when not having the Gelly gun.
+
+## Changed
+
+- Cleanup now clears all particles.
+
 ## [1.21.2] - 2024-08-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added a console command to clear particles when not having the Gelly gun.
+- Added a console command to clear particles while not having the Gelly Gun equipped.
 
-## Changed
+### Changed
 
-- Cleanup now clears all particles.
+- Map cleanup now clears all particles.
 
 ## [1.21.2] - 2024-08-25
 

--- a/packages/addon/lua/autorun/client/gelly-clear-command.lua
+++ b/packages/addon/lua/autorun/client/gelly-clear-command.lua
@@ -1,4 +1,5 @@
-
-concommand.Add("gelly_clear_particles", function()
-    gelly.Reset()
-end )
+hook.Add("GellyLoaded", "gelly.clear-particles-command", function()
+	concommand.Add("gelly_clear_particles", function()
+	    gelly.Reset()
+	end)
+end)

--- a/packages/addon/lua/autorun/client/gelly-clear-command.lua
+++ b/packages/addon/lua/autorun/client/gelly-clear-command.lua
@@ -1,0 +1,4 @@
+
+concommand.Add("gelly_clear_particles", function()
+    gelly.Reset()
+end )

--- a/packages/addon/lua/autorun/client/gelly-initialize.lua
+++ b/packages/addon/lua/autorun/client/gelly-initialize.lua
@@ -67,3 +67,7 @@ hook.Add("PostRender", "gelly.load-gelly", function()
 	-- also, add the particle system
 	game.AddParticles("particles/gelly.pcf")
 end)
+
+hook.Add("PreCleanupMap", "gelly.cleanup", function()
+	gelly.Reset()
+end)


### PR DESCRIPTION
## Ticket

Resolves #129
Resolves #130

## Changes

- Added a console command to clear particles when not having the Gelly gun.
- Cleanup now clears all particles.

