### PR TITLE
None fix ambient cube

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.2] - 2024-09-27
+
+### Fixed
+
+- Fixed Glunk being pitch black
+
 ## [1.22.1] - 2024-09-27
 
 ### Fixed

--- a/packages/gelly-gmod/src/composite/GModCompositor.h
+++ b/packages/gelly-gmod/src/composite/GModCompositor.h
@@ -28,10 +28,7 @@ public:
 	GModCompositor(GModCompositor &&) = delete;
 	GModCompositor &operator=(GModCompositor &&) = delete;
 
-	~GModCompositor() {
-		LOG_INFO("GModCompositor destructor called");
-		// we dont need to delete pipeline because it is a unique_ptr
-	}
+	~GModCompositor() = default;
 
 	void SetConfig(PipelineConfig config);
 	[[nodiscard]] PipelineConfig GetConfig() const;

--- a/packages/gelly-gmod/src/composite/standard/StandardPipeline.cpp
+++ b/packages/gelly-gmod/src/composite/standard/StandardPipeline.cpp
@@ -315,7 +315,9 @@ StandardPipeline::StandardPipeline(unsigned int width, unsigned height) :
 	compositeShader(),
 	quadVertexShader(),
 	width(width),
-	height(height) {}
+	height(height) {
+	SetupAmbientLightCubeHook();
+}
 
 StandardPipeline::~StandardPipeline() { RemoveAmbientLightCubeHooks(); }
 

--- a/packages/gelly-gmod/src/source/GetCubemap.cpp
+++ b/packages/gelly-gmod/src/source/GetCubemap.cpp
@@ -86,7 +86,7 @@ void __thiscall SetAmbientLightCubeHook(
 }
 
 void SetupAmbientLightCubeHook() {
-	if (!g_setAmbientLightCube) {
+	if (!g_setAmbientLightCube || g_setAmbientLightCubeHk) {
 		return;
 	}
 
@@ -118,9 +118,10 @@ void EnsureAllHandlesInitialized() {
 	}
 
 	if (g_getLocalCubemap && g_getD3DTexture && g_getTextureHandle &&
-		g_allowThreading) {
+		g_allowThreading && g_getLight && g_setAmbientLightCube) {
 		return;
 	}
+
 	LOG_INFO("Entering critical dbghelp section");
 	g_getLocalCubemap = g_materialSystem.FindFunction<GetLocalCubemap_t>(
 		sigs::CMaterialSystem_GetLocalCubemap

--- a/packages/gelly-gmod/src/source/GetCubemap.h
+++ b/packages/gelly-gmod/src/source/GetCubemap.h
@@ -67,6 +67,7 @@ std::optional<LightDesc_t> GetLightDesc(int index);
 int GetMaxLights();
 
 AmbientLightCube *GetAmbientLightCube();
+void SetupAmbientLightCubeHook();
 void RemoveAmbientLightCubeHooks();
 
 #endif	// GETCUBEMAP_H


### PR DESCRIPTION
## Ticket

<!-- The "Resolves" keyword will automatically close the issue when the PR is merged. -->
Resolves <!-- ticket number -->

## Changes

- Fixes the hook creation/deletion mismatch caused by StandardPipeline forcibly deleting ambient cube hooks upon deconstruction while never recreating them.

