### PR TITLE
141 & 139 - Fix pixelation and smooth albedo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.3] - 2024-09-28
+
+### Changed
+
+- Adjusted the mip curve such that waves and other details should still be preserved
+
+### Fixed
+
+- Fixed the pixelation of the fluid when the camera is close to the fluid.
+- Fixed fluid mixing being virtually non-existent.
+- **Note**: Fluid mixing is still not perfect, but it should be better than before. It **will not** be accurate, but it
+  should be less jarring.
+
 ## [1.22.2] - 2024-09-27
 
 ### Fixed

--- a/packages/gelly-gmod/src/composite/standard/StandardTextures.cpp
+++ b/packages/gelly-gmod/src/composite/standard/StandardTextures.cpp
@@ -60,7 +60,7 @@ void StandardTextures::CreateFeatureTextures() {
 		CreateTexture("gelly-gmod/position", D3DFMT_A32B32G32R32F);
 
 	std::tie(gmodTextures.thickness, sharedHandles.thickness) =
-		CreateTexture("gelly-gmod/thickness", D3DFMT_A16B16G16R16F, 1, 1.f);
+		CreateTexture("gelly-gmod/thickness", D3DFMT_A16B16G16R16F, 1, 0.1f);
 
 	std::tie(gmodTextures.foam, sharedHandles.foam) =
 		CreateTexture("gelly-gmod/foam", D3DFMT_A16B16G16R16F);

--- a/packages/gelly-gmod/src/composite/standard/StandardTextures.cpp
+++ b/packages/gelly-gmod/src/composite/standard/StandardTextures.cpp
@@ -54,7 +54,7 @@ void StandardTextures::CreateFeatureTextures() {
 		CreateTexture("gelly-gmod/normal", D3DFMT_A16B16G16R16F);
 
 	std::tie(gmodTextures.depth, sharedHandles.ellipsoidDepth) =
-		CreateTexture("gelly-gmod/depth", D3DFMT_A32B32G32R32F, 1, 1.f);
+		CreateTexture("gelly-gmod/depth", D3DFMT_A32B32G32R32F);
 
 	std::tie(gmodTextures.position, sharedHandles.positions) =
 		CreateTexture("gelly-gmod/position", D3DFMT_A32B32G32R32F);

--- a/packages/gelly-gmod/src/composite/standard/StandardTextures.cpp
+++ b/packages/gelly-gmod/src/composite/standard/StandardTextures.cpp
@@ -3,14 +3,14 @@
 #include <utility>
 
 std::pair<ComPtr<IDirect3DTexture9>, HANDLE> StandardTextures::CreateTexture(
-	const char *name, D3DFORMAT format, int levels
+	const char *name, D3DFORMAT format, int levels, float scale
 ) const {
 	HANDLE sharedHandle = nullptr;
 	ComPtr<IDirect3DTexture9> gmodTexture;
 
 	if (FAILED(gmodResources.device->CreateTexture(
-			width,
-			height,
+			width * scale,
+			height * scale,
 			levels,
 			D3DUSAGE_RENDERTARGET,
 			format,
@@ -48,19 +48,19 @@ void StandardTextures::CreateFeatureTextures() {
 		*/
 
 	std::tie(gmodTextures.albedo, sharedHandles.albedo) =
-		CreateTexture("gelly-gmod/albedo", D3DFMT_A16B16G16R16F);
+		CreateTexture("gelly-gmod/albedo", D3DFMT_A16B16G16R16F, 1, 0.1f);
 
 	std::tie(gmodTextures.normal, sharedHandles.normals) =
 		CreateTexture("gelly-gmod/normal", D3DFMT_A16B16G16R16F);
 
 	std::tie(gmodTextures.depth, sharedHandles.ellipsoidDepth) =
-		CreateTexture("gelly-gmod/depth", D3DFMT_A32B32G32R32F);
+		CreateTexture("gelly-gmod/depth", D3DFMT_A32B32G32R32F, 1, 1.f);
 
 	std::tie(gmodTextures.position, sharedHandles.positions) =
 		CreateTexture("gelly-gmod/position", D3DFMT_A32B32G32R32F);
 
 	std::tie(gmodTextures.thickness, sharedHandles.thickness) =
-		CreateTexture("gelly-gmod/thickness", D3DFMT_A16B16G16R16F);
+		CreateTexture("gelly-gmod/thickness", D3DFMT_A16B16G16R16F, 1, 1.f);
 
 	std::tie(gmodTextures.foam, sharedHandles.foam) =
 		CreateTexture("gelly-gmod/foam", D3DFMT_A16B16G16R16F);

--- a/packages/gelly-gmod/src/composite/standard/StandardTextures.h
+++ b/packages/gelly-gmod/src/composite/standard/StandardTextures.h
@@ -21,7 +21,7 @@ private:
 	unsigned int height;
 
 	std::pair<ComPtr<IDirect3DTexture9>, HANDLE> CreateTexture(
-		const char *name, D3DFORMAT format, int levels = 1
+		const char *name, D3DFORMAT format, int levels = 1, float scale = 1.f
 	) const;
 
 	void CreateFeatureTextures();

--- a/packages/gelly/modules/gelly-fluid-renderer/src/shaders/AlbedoDownsample.ps50.hlsl
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/shaders/AlbedoDownsample.ps50.hlsl
@@ -4,23 +4,40 @@
 Texture2D InputAlbedo : register(t0);
 SamplerState InputAlbedoSampler : register(s0);
 
+Texture2D InputThickness : register(t1);
+SamplerState InputThicknessSampler : register(s1);
+
 struct PS_OUTPUT {
 	float4 Albedo : SV_Target0;
+	float Thickness : SV_Target1;
 };
 
 PS_OUTPUT main(VS_OUTPUT input) {
 	PS_OUTPUT output = (PS_OUTPUT)0;
-	// Quick cross filter, its a little easier on the eyes
 	float2 uv = input.Tex;
-	float2 texelSize = 1.f / float2(g_ViewportWidth, g_ViewportHeight);
+	float2 texelSize = float2(1.0 / g_ViewportWidth, 1.0 / g_ViewportHeight);
 
-	float4 nx = InputAlbedo.Sample(InputAlbedoSampler, uv + float2(-texelSize.x, 0));
-	float4 px = InputAlbedo.Sample(InputAlbedoSampler, uv + float2(texelSize.x, 0));
-	float4 ny = InputAlbedo.Sample(InputAlbedoSampler, uv + float2(0, -texelSize.y));
-	float4 py = InputAlbedo.Sample(InputAlbedoSampler, uv + float2(0, texelSize.y));
-	float4 center = InputAlbedo.Sample(InputAlbedoSampler, uv);
+	float3 albedoTaps[9] = {
+		InputAlbedo.Sample(InputAlbedoSampler, uv + float2(-1, -1) * texelSize).rgb,
+		InputAlbedo.Sample(InputAlbedoSampler, uv + float2(0, -1) * texelSize).rgb,
+		InputAlbedo.Sample(InputAlbedoSampler, uv + float2(1, -1) * texelSize).rgb,
+		InputAlbedo.Sample(InputAlbedoSampler, uv + float2(-1, 0) * texelSize).rgb,
+		InputAlbedo.Sample(InputAlbedoSampler, uv + float2(0, 0) * texelSize).rgb,
+		InputAlbedo.Sample(InputAlbedoSampler, uv + float2(1, 0) * texelSize).rgb,
+		InputAlbedo.Sample(InputAlbedoSampler, uv + float2(-1, 1) * texelSize).rgb,
+		InputAlbedo.Sample(InputAlbedoSampler, uv + float2(0, 1) * texelSize).rgb,
+		InputAlbedo.Sample(InputAlbedoSampler, uv + float2(1, 1) * texelSize).rgb
+	};
 
-	float4 outputColor = (nx + px + ny + py + center) / 5.f;
-	output.Albedo = outputColor;
+	float3 albedo = 0;
+	[unroll]
+	for (int i = 0; i < 9; i++) {
+		albedo += albedoTaps[i];
+	}
+
+	albedo /= 9.0f;
+	
+	output.Albedo = float4(albedo, 1.0f);
+	output.Thickness = InputThickness.Sample(InputThicknessSampler, uv).r;
 	return output;
 }

--- a/packages/gelly/modules/gelly-fluid-renderer/src/shaders/AlbedoDownsample.ps50.hlsl
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/shaders/AlbedoDownsample.ps50.hlsl
@@ -1,0 +1,26 @@
+#include "FluidRenderCBuffer.hlsli"
+#include "ScreenQuadStructs.hlsli"
+
+Texture2D InputAlbedo : register(t0);
+SamplerState InputAlbedoSampler : register(s0);
+
+struct PS_OUTPUT {
+	float4 Albedo : SV_Target0;
+};
+
+PS_OUTPUT main(VS_OUTPUT input) {
+	PS_OUTPUT output = (PS_OUTPUT)0;
+	// Quick cross filter, its a little easier on the eyes
+	float2 uv = input.Tex;
+	float2 texelSize = 1.f / float2(g_ViewportWidth, g_ViewportHeight);
+
+	float4 nx = InputAlbedo.Sample(InputAlbedoSampler, uv + float2(-texelSize.x, 0));
+	float4 px = InputAlbedo.Sample(InputAlbedoSampler, uv + float2(texelSize.x, 0));
+	float4 ny = InputAlbedo.Sample(InputAlbedoSampler, uv + float2(0, -texelSize.y));
+	float4 py = InputAlbedo.Sample(InputAlbedoSampler, uv + float2(0, texelSize.y));
+	float4 center = InputAlbedo.Sample(InputAlbedoSampler, uv);
+
+	float4 outputColor = (nx + px + ny + py + center) / 5.f;
+	output.Albedo = outputColor;
+	return output;
+}

--- a/packages/gelly/modules/gelly-fluid-renderer/src/shaders/EstimateNormal.ps50.hlsl
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/shaders/EstimateNormal.ps50.hlsl
@@ -115,6 +115,10 @@ PS_OUTPUT main(VS_OUTPUT input) {
 
     float3 normal = -normalize(cross(dpdx, dpdy));
 
+	if (isnan(normal.x) || isnan(normal.y) || isnan(normal.z)) {
+		discard;
+	}
+
     output.PositiveNormal = float4(normal, 1.f);
     output.WorldPosition = float4(WorldPosFromDepthF(input.Tex, centerTap.r), 1.f);
     return output;

--- a/packages/gelly/modules/gelly-fluid-renderer/src/shaders/FilterDepth.ps50.hlsl
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/shaders/FilterDepth.ps50.hlsl
@@ -30,7 +30,7 @@ float3 FetchNormal(float2 pixel, float eyeDepth) {
 	// This term cheaply accounts for higher depth discontinuities across
 	// high radius particles
 	float radiusAdjustmentTerm = 0.2f * g_ParticleRadius;
-	float mipLevel = 8 - 1.3f * log2((0.2f * abs(eyeDepth)) + 0.0001f) + radiusAdjustmentTerm;
+	float mipLevel = 8 - 3.f * log2((0.05f * abs(eyeDepth)) + 0.0001f) + radiusAdjustmentTerm;
 	mipLevel = clamp(mipLevel, 0, NORMAL_MIP_LEVEL);
 
 	float2 uv = pixel / float2(g_ViewportWidth, g_ViewportHeight);

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/pipeline/pipeline.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/pipeline/pipeline.h
@@ -55,6 +55,9 @@ public:
 		-> std::shared_ptr<Pipeline>;
 
 	auto Run(std::optional<int> vertexCount = std::nullopt) -> void;
+	auto GetRenderPass() const -> std::shared_ptr<RenderPass> {
+		return createInfo.renderPass;
+	}
 
 private:
 	PipelineCreateInfo createInfo;

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/pipeline/render-pass.cpp
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/pipeline/render-pass.cpp
@@ -81,8 +81,8 @@ auto RenderPass::CreateViewport() -> D3D11_VIEWPORT {
 	D3D11_VIEWPORT viewport = {};
 	viewport.TopLeftX = passInfo.viewportState.topLeftX;
 	viewport.TopLeftY = passInfo.viewportState.topLeftY;
-	viewport.Width = passInfo.viewportState.width;
-	viewport.Height = passInfo.viewportState.height;
+	viewport.Width = GetScaledWidth();
+	viewport.Height = GetScaledHeight();
 	viewport.MinDepth = passInfo.viewportState.minDepth;
 	viewport.MaxDepth = passInfo.viewportState.maxDepth;
 

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/pipeline/render-pass.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/pipeline/render-pass.h
@@ -92,6 +92,12 @@ public:
 		return passInfo.viewportState.height * passInfo.outputScale;
 	}
 
+	// For some use-cases, we might want to disable mip regeneration or enable
+	// it on the fly
+	auto SetMipRegenerationEnabled(bool enabled) -> void {
+		passInfo.enableMipRegeneration = enabled;
+	}
+
 private:
 	PassInfo passInfo;
 	ComPtr<ID3D11DepthStencilState> depthStencilState;

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/pipeline/render-pass.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/pipeline/render-pass.h
@@ -58,6 +58,16 @@ public:
 		RasterizerState rasterizerState;
 		std::optional<BlendState> blendState = std::nullopt;
 		bool enableMipRegeneration = true;
+		/**
+		 * This scales all of the output of this render pass by this factor.
+		 * So, if you have a 1920x1080 pass and you set this to 0.5, the output
+		 * is 960x540.
+		 *
+		 * It is your responsibility to let the shader know about this scale,
+		 * you may retrieve the factor with GetScaleOutput() in the render pass
+		 * object.
+		 */
+		float outputScale = 1.0f;
 	};
 
 	RenderPass(const PassInfo &passInfo);
@@ -70,6 +80,16 @@ public:
 
 	auto IsMipRegenerationEnabled() const -> bool {
 		return passInfo.enableMipRegeneration;
+	}
+
+	auto GetOutputScale() const -> float { return passInfo.outputScale; }
+
+	auto GetScaledWidth() const -> float {
+		return passInfo.viewportState.width * passInfo.outputScale;
+	}
+
+	auto GetScaledHeight() const -> float {
+		return passInfo.viewportState.height * passInfo.outputScale;
 	}
 
 private:

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/pipelines/albedo-downsampling.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/pipelines/albedo-downsampling.h
@@ -1,0 +1,73 @@
+#ifndef ALBEDO_DOWNSAMPLING_H
+#define ALBEDO_DOWNSAMPLING_H
+
+#include <device.h>
+#include <helpers/create-gsc-shader.h>
+#include <pipeline/pipeline.h>
+
+#include <memory>
+#include <optional>
+
+#include "AlbedoDownsamplePS.h"
+#include "helpers/rendering/screen-quad.h"
+#include "pipeline-info.h"
+
+namespace gelly {
+namespace renderer {
+namespace splatting {
+inline auto CreateAlbedoDownsamplingPipeline(
+	const PipelineInfo &info, float outputScale
+) -> std::shared_ptr<Pipeline> {
+	const auto renderPass = std::make_shared<RenderPass>(RenderPass::PassInfo{
+		.device = info.device,
+		.depthStencilState =
+			{.depthTestEnabled = false,
+			 .depthWriteEnabled = false,
+			 .depthComparisonFunc = D3D11_COMPARISON_ALWAYS},
+		.viewportState =
+			{.topLeftX = 0.f,
+			 .topLeftY = 0.f,
+			 .width = static_cast<float>(info.width),
+			 .height = static_cast<float>(info.height),
+			 .minDepth = 0.f,
+			 .maxDepth = 1.f},
+		.rasterizerState =
+			{.fillMode = D3D11_FILL_SOLID, .cullMode = D3D11_CULL_NONE},
+		.outputScale = outputScale
+	});
+
+	const util::ScreenQuad screenQuad({.device = info.device});
+
+	return Pipeline::CreatePipeline(
+		{.name = "Downsampling albedo",
+		 .device = info.device,
+		 .renderPass = renderPass,
+		 .inputLayout = screenQuad.GetInputLayout(),
+		 .primitiveTopology = util::ScreenQuad::GetPrimitiveTopology(),
+		 .inputs =
+			 {screenQuad.GetVertexBuffer(),
+			  InputTexture{
+				  .texture = info.internalTextures->unfilteredAlbedo,
+				  .bindFlag = D3D11_BIND_SHADER_RESOURCE,
+				  .slot = 0
+			  }},
+		 .outputs = {OutputTexture{
+			 .texture = info.outputTextures->albedo,
+			 .bindFlag = D3D11_BIND_RENDER_TARGET,
+			 .slot = 0,
+			 .clearColor = {0.f, 0.f, 0.f, 0.f}
+		 }},
+		 .shaderGroup =
+			 {.pixelShader = PS_FROM_GSC(AlbedoDownsamplePS, info.device),
+			  .vertexShader = screenQuad.GetVertexShader(),
+			  .constantBuffers =
+				  {info.internalBuffers->fluidRenderCBuffer.GetBuffer()}},
+		 .depthBuffer = std::nullopt,
+		 .defaultVertexCount = 4}
+	);
+}
+}  // namespace splatting
+}  // namespace renderer
+}  // namespace gelly
+
+#endif	// ALBEDO_DOWNSAMPLING_H

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/pipelines/albedo-downsampling.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/pipelines/albedo-downsampling.h
@@ -50,13 +50,25 @@ inline auto CreateAlbedoDownsamplingPipeline(
 				  .texture = info.internalTextures->unfilteredAlbedo,
 				  .bindFlag = D3D11_BIND_SHADER_RESOURCE,
 				  .slot = 0
+			  },
+			  InputTexture{
+				  .texture = info.internalTextures->unfilteredThickness,
+				  .bindFlag = D3D11_BIND_SHADER_RESOURCE,
+				  .slot = 1
 			  }},
-		 .outputs = {OutputTexture{
-			 .texture = info.outputTextures->albedo,
-			 .bindFlag = D3D11_BIND_RENDER_TARGET,
-			 .slot = 0,
-			 .clearColor = {0.f, 0.f, 0.f, 0.f}
-		 }},
+		 .outputs =
+			 {OutputTexture{
+				  .texture = info.outputTextures->albedo,
+				  .bindFlag = D3D11_BIND_RENDER_TARGET,
+				  .slot = 0,
+				  .clearColor = {0.f, 0.f, 0.f, 0.f}
+			  },
+			  OutputTexture{
+				  .texture = info.outputTextures->thickness,
+				  .bindFlag = D3D11_BIND_RENDER_TARGET,
+				  .slot = 1,
+				  .clearColor = {0.f, 0.f, 0.f, 0.f}
+			  }},
 		 .shaderGroup =
 			 {.pixelShader = PS_FROM_GSC(AlbedoDownsamplePS, info.device),
 			  .vertexShader = screenQuad.GetVertexShader(),

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/pipelines/ellipsoid-splatting.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/pipelines/ellipsoid-splatting.h
@@ -173,7 +173,7 @@ inline auto CreateEllipsoidSplattingPipeline(
 				  .clearColor = {1.f, D3D11_FLOAT32_MAX, 1.f, 1.f}
 			  },
 			  OutputTexture{
-				  .texture = info.outputTextures->thickness,
+				  .texture = info.internalTextures->unfilteredThickness,
 				  .bindFlag = D3D11_BIND_RENDER_TARGET,
 				  .slot = 2,
 				  .clearColor = {0.f, 0.f, 0.f, 0.f}

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/pipelines/ellipsoid-splatting.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/pipelines/ellipsoid-splatting.h
@@ -20,8 +20,9 @@ namespace gelly {
 namespace renderer {
 namespace splatting {
 
-inline auto CreateEllipsoidSplattingPipeline(const PipelineInfo &info)
-	-> std::shared_ptr<Pipeline> {
+inline auto CreateEllipsoidSplattingPipeline(
+	const PipelineInfo &info, float outputScale = 1.f
+) -> std::shared_ptr<Pipeline> {
 	const auto renderPass = std::make_shared<RenderPass>(RenderPass::PassInfo{
 		.device = info.device,
 		.depthStencilState =
@@ -81,6 +82,7 @@ inline auto CreateEllipsoidSplattingPipeline(const PipelineInfo &info)
 					 .RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL,
 				 }},
 		}},
+		.outputScale = outputScale
 	});
 
 	const auto vertexShader = VS_FROM_GSC(SplattingVS, info.device);
@@ -159,7 +161,7 @@ inline auto CreateEllipsoidSplattingPipeline(const PipelineInfo &info)
 			  }},
 		 .outputs =
 			 {OutputTexture{
-				  .texture = info.outputTextures->albedo,
+				  .texture = info.internalTextures->unfilteredAlbedo,
 				  .bindFlag = D3D11_BIND_RENDER_TARGET,
 				  .slot = 0,
 				  .clearColor = {0.f, 0.f, 0.f, 0.f},
@@ -171,12 +173,10 @@ inline auto CreateEllipsoidSplattingPipeline(const PipelineInfo &info)
 				  .clearColor = {1.f, D3D11_FLOAT32_MAX, 1.f, 1.f}
 			  },
 			  OutputTexture{
-				  .texture =
-					  info.outputTextures->thickness,
+				  .texture = info.outputTextures->thickness,
 				  .bindFlag = D3D11_BIND_RENDER_TARGET,
 				  .slot = 2,
-				  .clearColor =
-					  {0.f, 0.f, 0.f, 0.f}
+				  .clearColor = {0.f, 0.f, 0.f, 0.f}
 			  }},
 		 .shaderGroup =
 			 {.pixelShader = PS_FROM_GSC(SplattingPS, info.device),

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/splatting-renderer.cpp
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/splatting-renderer.cpp
@@ -222,7 +222,19 @@ auto SplattingRenderer::RunSurfaceFilteringPipeline(unsigned int iterations
 	}
 
 	for (int i = 0; i < iterations; i++) {
+		bool oddIteration = i % 2 != 0;
 		if (settings.enableSurfaceFiltering) {
+			// This helps control the propagation of the normals across the mip
+			// chain. If we allow the mip regeneration to happen for every
+			// iteration, the depth-based filter quickly becomes overwhelmed by
+			// the footprint of smaller mips.
+			surfaceFilteringA->GetRenderPass()->SetMipRegenerationEnabled(
+				oddIteration
+			);
+			surfaceFilteringB->GetRenderPass()->SetMipRegenerationEnabled(
+				oddIteration
+			);
+
 			surfaceFilteringA->Run();
 			surfaceFilteringB->Run();
 		}

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/splatting-renderer.cpp
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/splatting-renderer.cpp
@@ -1,5 +1,6 @@
 #include "splatting-renderer.h"
 
+#include "pipelines/albedo-downsampling.h"
 #include "pipelines/ellipsoid-splatting.h"
 #include "pipelines/normal-estimation.h"
 #include "pipelines/surface-filtering.h"
@@ -50,7 +51,7 @@ auto SplattingRenderer::Create(const SplattingRendererCreateInfo &&createInfo)
 	return std::make_shared<SplattingRenderer>(createInfo);
 }
 
-auto SplattingRenderer::Render() const -> void {
+auto SplattingRenderer::Render() -> void {
 #ifdef GELLY_ENABLE_RENDERDOC_CAPTURES
 	if (renderDoc) {
 		renderDoc->StartFrameCapture(
@@ -58,7 +59,17 @@ auto SplattingRenderer::Render() const -> void {
 		);
 	}
 #endif
+
 	ellipsoidSplatting->Run(createInfo.simData->GetActiveParticles());
+	SetFrameResolution(
+		albedoDownsampling->GetRenderPass()->GetScaledWidth(),
+		albedoDownsampling->GetRenderPass()->GetScaledHeight()
+	);
+	albedoDownsampling->Run();
+	SetFrameResolution(
+		surfaceFilteringA->GetRenderPass()->GetScaledWidth(),
+		surfaceFilteringA->GetRenderPass()->GetScaledHeight()
+	);
 	rawNormalEstimation->Run();
 	RunSurfaceFilteringPipeline(settings.filterIterations);
 #ifdef GELLY_ENABLE_RENDERDOC_CAPTURES
@@ -93,13 +104,27 @@ auto SplattingRenderer::UpdateSettings(const Settings &settings) -> void {
 	this->settings = settings;
 }
 
-auto SplattingRenderer::UpdateFrameParams(cbuffer::FluidRenderCBufferData &data
-) const -> void {
+auto SplattingRenderer::UpdateFrameParams(cbuffer::FluidRenderCBufferData &data)
+	-> void {
 	pipelineInfo.internalBuffers->fluidRenderCBuffer.UpdateBuffer(data);
+	std::memcpy(
+		&frameParamCopy, &data, sizeof(cbuffer::FluidRenderCBufferData)
+	);
+}
+
+auto SplattingRenderer::SetFrameResolution(float width, float height) -> void {
+	frameParamCopy.g_ViewportWidth = width;
+	frameParamCopy.g_ViewportHeight = height;
+
+	pipelineInfo.internalBuffers->fluidRenderCBuffer.UpdateBuffer(frameParamCopy
+	);
 }
 
 auto SplattingRenderer::CreatePipelines() -> void {
 	ellipsoidSplatting = CreateEllipsoidSplattingPipeline(pipelineInfo);
+	albedoDownsampling =
+		CreateAlbedoDownsamplingPipeline(pipelineInfo, ALBEDO_OUTPUT_SCALE);
+
 	surfaceFilteringA = CreateSurfaceFilteringPipeline(
 		pipelineInfo,
 		pipelineInfo.internalTextures->unfilteredNormals,

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/splatting-renderer.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/splatting-renderer.h
@@ -36,6 +36,8 @@ private:
 
 class SplattingRenderer {
 public:
+	float ALBEDO_OUTPUT_SCALE = 0.1f;
+
 	struct Settings {
 		unsigned int filterIterations = 5;
 		/**
@@ -65,8 +67,9 @@ public:
 	static auto Create(const SplattingRendererCreateInfo &&createInfo)
 		-> std::shared_ptr<SplattingRenderer>;
 
-	auto Render() const -> void;
-	auto UpdateFrameParams(cbuffer::FluidRenderCBufferData &data) const -> void;
+	auto Render() -> void;
+	auto UpdateFrameParams(cbuffer::FluidRenderCBufferData &data) -> void;
+	auto SetFrameResolution(float width, float height) -> void;
 	auto GetSettings() const -> Settings;
 	auto UpdateSettings(const Settings &settings) -> void;
 	[[nodiscard]] auto GetAbsorptionModifier() const
@@ -80,10 +83,12 @@ private:
 
 	PipelineInfo pipelineInfo;
 	PipelinePtr ellipsoidSplatting;
+	PipelinePtr albedoDownsampling;
 	PipelinePtr surfaceFilteringA;
 	PipelinePtr surfaceFilteringB;
 	PipelinePtr rawNormalEstimation;
 
+	cbuffer::FluidRenderCBufferData frameParamCopy = {};
 #ifdef GELLY_ENABLE_RENDERDOC_CAPTURES
 	RENDERDOC_API_1_1_2 *renderDoc = nullptr;
 #endif


### PR DESCRIPTION
## Ticket

<!-- The "Resolves" keyword will automatically close the issue when the PR is merged. -->
Resolves #141 
Resolves #139 

## Changes

- Exposes output scaling and mip regen dynamically for every pipeline
- Introduces a new downsampler pipeline, `AlbedoDownsampling` which currently box blurs albedo and downsamples thickness
- Propagates normal changes every odd iteration
- Mip curve adjusted

