### PR TITLE
NONE - Fix teleportation bug & forcefield bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.1] - 2024-10-01
+
+### Fixed
+
+- Fixed the **infamous** teleportation bug that caused the fluid to teleport randomly when props were spawned.
+- Fixed the forcefield bug in which a silhouette of the last spawned prop would appear when the forcefield was active.
+
 ## [1.23.0] - 2024-10-01
 
 ### Added

--- a/packages/addon/lua/autorun/client/gelly-object-management.lua
+++ b/packages/addon/lua/autorun/client/gelly-object-management.lua
@@ -46,7 +46,6 @@ local function addObject(entity)
 	end
 
 	table.insert(objectHandles, entity:EntIndex())
-
 	objects[entity] = objectHandles
 end
 
@@ -63,6 +62,9 @@ end
 
 local function updateObject(entity)
 	local objectHandles = objects[entity]
+	if not objectHandles then
+		return
+	end
 
 	for _, objectHandle in ipairs(objectHandles) do
 		if not IsValid(entity) then
@@ -99,7 +101,13 @@ hook.Add("GellyLoaded", "gelly.object-management-initialize", function()
 		end)
 
 	hook.Add("OnEntityCreated", "gelly.object-add", function(entity)
-		addObject(entity)
+		timer.Simple(0, function()
+			-- Empirical fix for teleportation:
+			-- After much experimentation, Gelly was proven to be properly handling entity updates,
+			-- but GMod is actually the issue--giving us the wrong entity position immediately after creation.
+			addObject(entity)
+			updateObject(entity)
+		end)
 	end)
 
 	hook.Add("EntityRemoved", "gelly.object-remove", function(entity)

--- a/packages/gelly/modules/gelly-fluid-sim/include/fluidsim/CFlexSimScene.h
+++ b/packages/gelly/modules/gelly-fluid-sim/include/fluidsim/CFlexSimScene.h
@@ -24,6 +24,10 @@ struct ObjectData {
 	ObjectShape shape{};
 	float position[3]{};
 	float rotation[4]{};
+
+	float appliedPosition[3]{};
+	float appliedRotation[4]{};
+
 	bool firstFrame = true;
 
 	std::variant<TriangleMesh, Capsule, ObjectCreationParams::Forcefield>

--- a/packages/gelly/modules/gelly-fluid-sim/include/fluidsim/ISimScene.h
+++ b/packages/gelly/modules/gelly-fluid-sim/include/fluidsim/ISimScene.h
@@ -67,6 +67,7 @@ struct ObjectCreationParams {
 using ObjectHandle = uint;
 
 constexpr ObjectHandle INVALID_OBJECT_HANDLE = 0xFFFFFFFF;
+constexpr ObjectHandle WORLD_HANDLE = 0;
 }  // namespace Gelly
 
 using namespace Gelly;


### PR DESCRIPTION
## Ticket

<!-- The "Resolves" keyword will automatically close the issue when the PR is merged. -->
Resolves <!-- ticket number -->

## Changes

- Adds an `applied` copy of the object properties in `CFlexSimScene` to ensure all position updates get applied
- Delay the addition of any new objects by a frame to avoid adding an object with null data (what caused the TP bug)
- Remove forcefields from being counted as an object
