### PR TITLE
89 - Improved performance debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2024-10-05
+
+### Added
+
+- Added more information to `gelly_performance_debugger`, which is incredibly useful for debugging slow performance.
+
+### Fixed
+
+- Fixed flushing rendering commands when the query would do it anyways
+
 ## [1.24.0] - 2024-10-04
 
 ### Added

--- a/packages/gelly-gmod/src/composite/GModCompositor.h
+++ b/packages/gelly-gmod/src/composite/GModCompositor.h
@@ -63,6 +63,10 @@ public:
 	) const {
 		gellyResources.splattingRenderer->UpdateSettings(settings);
 	}
+
+	[[nodiscard]] SplattingRenderer::Timings FetchGellyTimings() const {
+		return gellyResources.splattingRenderer->FetchTimings();
+	}
 };
 
 #endif	// COMPOSITE_H

--- a/packages/gelly-gmod/src/main.cpp
+++ b/packages/gelly-gmod/src/main.cpp
@@ -724,11 +724,13 @@ LUA_FUNCTION(gelly_SetGellySettings) {
 
 	GET_LUA_TABLE_MEMBER(float, FilterIterations);
 	GET_LUA_TABLE_MEMBER(bool, EnableGPUSynchronization);
+	GET_LUA_TABLE_MEMBER(bool, EnableGPUTiming);
 
 	int filterIterations = static_cast<int>(FilterIterations);
 	auto currentSettings = compositor->GetGellySettings();
 	currentSettings.filterIterations = filterIterations;
 	currentSettings.enableGPUSynchronization = EnableGPUSynchronization_b;
+	currentSettings.enableGPUTiming = EnableGPUTiming_b;
 
 	compositor->UpdateGellySettings(currentSettings);
 	CATCH_GELLY_EXCEPTIONS();
@@ -744,6 +746,28 @@ LUA_FUNCTION(gelly_GetGellySettings) {
 	LUA->SetField(-2, "FilterIterations");
 	LUA->PushBool(currentSettings.enableGPUSynchronization);
 	LUA->SetField(-2, "EnableGPUSynchronization");
+	LUA->PushBool(currentSettings.enableGPUTiming);
+	LUA->SetField(-2, "EnableGPUTiming");
+
+	CATCH_GELLY_EXCEPTIONS();
+	return 1;
+}
+
+LUA_FUNCTION(gelly_GetGellyTimings) {
+	START_GELLY_EXCEPTIONS();
+	auto timings = compositor->FetchGellyTimings();
+
+	LUA->CreateTable();
+	LUA->PushNumber(timings.albedoDownsampling);
+	LUA->SetField(-2, "AlbedoDownsampling");
+	LUA->PushNumber(timings.ellipsoidSplatting);
+	LUA->SetField(-2, "EllipsoidSplatting");
+	LUA->PushNumber(timings.surfaceFiltering);
+	LUA->SetField(-2, "SurfaceFiltering");
+	LUA->PushNumber(timings.rawNormalEstimation);
+	LUA->SetField(-2, "RawNormalEstimation");
+	LUA->PushBool(timings.isDisjoint);
+	LUA->SetField(-2, "IsDisjoint");
 
 	CATCH_GELLY_EXCEPTIONS();
 	return 1;
@@ -971,6 +995,7 @@ extern "C" __declspec(dllexport) int gmod13_open(lua_State *L) {
 	DEFINE_LUA_FUNC(gelly, GetVersion);
 	DEFINE_LUA_FUNC(gelly, SetGellySettings);
 	DEFINE_LUA_FUNC(gelly, GetGellySettings);
+	DEFINE_LUA_FUNC(gelly, GetGellyTimings);
 	DEFINE_LUA_FUNC(gelly, ConfigureSim);
 	DEFINE_LUA_FUNC(gelly, SetSunDirection);
 	DEFINE_LUA_FUNC(gelly, SetSunEnabled);

--- a/packages/gelly/modules/gelly-fluid-renderer/CMakeLists.txt
+++ b/packages/gelly/modules/gelly-fluid-renderer/CMakeLists.txt
@@ -50,6 +50,8 @@ add_library(
         src/v2/renderers/splatting/splatting-renderer.cpp
         src/v2/renderers/splatting/splatting-renderer.h
         src/v2/renderers/splatting/reload-shaders.h
+        src/v2/helpers/rendering/gpu-duration.h
+        src/v2/helpers/rendering/gpu-duration.cpp
 )
 
 target_include_directories(

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/helpers/rendering/gpu-duration.cpp
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/helpers/rendering/gpu-duration.cpp
@@ -1,0 +1,99 @@
+#include "gpu-duration.h"
+
+#include <stdexcept>
+
+#include "helpers/throw-informative-exception.h"
+
+namespace gelly {
+namespace renderer {
+namespace util {
+
+GPUDuration::GPUDuration(const std::shared_ptr<Device> &device) :
+	device(device),
+	timestampBegin(CreateTimestampQuery()),
+	timestampEnd(CreateTimestampQuery()),
+	timestampDisjoint(CreateTimestampDisjointQuery()),
+	timestampBeginValue(0),
+	timestampEndValue(0),
+	timestampDisjointData() {}
+
+auto GPUDuration::Start() -> void {
+	device->GetRawDeviceContext()->Begin(timestampDisjoint.Get());
+	device->GetRawDeviceContext()->End(timestampBegin.Get());
+}
+
+auto GPUDuration::End() -> void {
+	device->GetRawDeviceContext()->End(timestampEnd.Get());
+	device->GetRawDeviceContext()->End(timestampDisjoint.Get());
+}
+
+auto GPUDuration::WaitForData() -> void {
+	while (device->GetRawDeviceContext()->GetData(
+			   timestampDisjoint.Get(),
+			   &timestampDisjointData,
+			   sizeof(D3D11_QUERY_DATA_TIMESTAMP_DISJOINT),
+			   0
+		   ) != S_OK) {
+		Sleep(0);
+	}
+
+	while (device->GetRawDeviceContext()->GetData(
+			   timestampBegin.Get(), &timestampBeginValue, sizeof(UINT64), 0
+		   ) != S_OK) {
+		Sleep(0);
+	}
+
+	while (device->GetRawDeviceContext()->GetData(
+			   timestampEnd.Get(), &timestampEndValue, sizeof(UINT64), 0
+		   ) != S_OK) {
+		Sleep(0);
+	}
+}
+
+auto GPUDuration::GetDuration() -> float {
+	WaitForData();
+
+	auto delta = timestampEndValue - timestampBeginValue;
+	auto frequency = timestampDisjointData.Frequency;
+
+	auto deltaInSeconds =
+		static_cast<float>(delta) / static_cast<float>(frequency);
+
+	return deltaInSeconds * 1000.0f;
+}
+
+auto GPUDuration::CreateTimestampQuery() -> ComPtr<ID3D11Query> {
+	ComPtr<ID3D11Query> query;
+	D3D11_QUERY_DESC queryDesc = {};
+	queryDesc.Query = D3D11_QUERY_TIMESTAMP;
+	queryDesc.MiscFlags = 0;
+
+	const auto result =
+		device->GetRawDevice()->CreateQuery(&queryDesc, query.GetAddressOf());
+
+	GELLY_RENDERER_THROW_ON_FAIL(
+		result, std::runtime_error, "Failed to create timestamp query"
+	);
+
+	return query;
+}
+
+auto GPUDuration::CreateTimestampDisjointQuery() -> ComPtr<ID3D11Query> {
+	ComPtr<ID3D11Query> query;
+	D3D11_QUERY_DESC queryDesc = {};
+	queryDesc.Query = D3D11_QUERY_TIMESTAMP_DISJOINT;
+	queryDesc.MiscFlags = 0;
+
+	const auto result =
+		device->GetRawDevice()->CreateQuery(&queryDesc, query.GetAddressOf());
+
+	GELLY_RENDERER_THROW_ON_FAIL(
+		result, std::runtime_error, "Failed to create timestamp disjoint query"
+	);
+
+	return query;
+}
+
+}  // namespace util
+}  // namespace renderer
+}  // namespace gelly

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/helpers/rendering/gpu-duration.cpp
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/helpers/rendering/gpu-duration.cpp
@@ -48,10 +48,14 @@ auto GPUDuration::WaitForData() -> void {
 		   ) != S_OK) {
 		Sleep(0);
 	}
+
+	dataFetched = true;
 }
 
 auto GPUDuration::GetDuration() -> float {
-	WaitForData();
+	if (!dataFetched) {
+		WaitForData();
+	}
 
 	auto delta = timestampEndValue - timestampBeginValue;
 	auto frequency = timestampDisjointData.Frequency;
@@ -60,6 +64,14 @@ auto GPUDuration::GetDuration() -> float {
 		static_cast<float>(delta) / static_cast<float>(frequency);
 
 	return deltaInSeconds * 1000.0f;
+}
+
+auto GPUDuration::IsDisjoint() -> bool {
+	if (!dataFetched) {
+		WaitForData();
+	}
+
+	return timestampDisjointData.Disjoint == TRUE;
 }
 
 auto GPUDuration::CreateTimestampQuery() -> ComPtr<ID3D11Query> {

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/helpers/rendering/gpu-duration.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/helpers/rendering/gpu-duration.h
@@ -1,0 +1,46 @@
+#ifndef GPU_DURATION_H
+#define GPU_DURATION_H
+#include <memory>
+
+#include "device.h"
+
+namespace gelly {
+namespace renderer {
+namespace util {
+
+class GPUDuration {
+public:
+	GPUDuration(const std::shared_ptr<Device> &device);
+	~GPUDuration() = default;
+
+	auto Start() -> void;
+	auto End() -> void;
+
+	/**
+	 * Will forcibly end the GPU operation and return the duration, so use this
+	 * at the end of a scope.
+	 * @return The duration of the GPU operation in milliseconds.
+	 */
+	auto GetDuration() -> float;
+
+private:
+	std::shared_ptr<Device> device;
+
+	ComPtr<ID3D11Query> timestampBegin;
+	ComPtr<ID3D11Query> timestampEnd;
+	ComPtr<ID3D11Query> timestampDisjoint;
+
+	UINT64 timestampBeginValue;
+	UINT64 timestampEndValue;
+	D3D11_QUERY_DATA_TIMESTAMP_DISJOINT timestampDisjointData;
+
+	auto CreateTimestampQuery() -> ComPtr<ID3D11Query>;
+	auto CreateTimestampDisjointQuery() -> ComPtr<ID3D11Query>;
+
+	auto WaitForData() -> void;
+};
+
+}  // namespace util
+}  // namespace renderer
+}  // namespace gelly
+#endif	// GPU_DURATION_H

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/helpers/rendering/gpu-duration.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/helpers/rendering/gpu-duration.h
@@ -22,6 +22,7 @@ public:
 	 * @return The duration of the GPU operation in milliseconds.
 	 */
 	auto GetDuration() -> float;
+	auto IsDisjoint() -> bool;
 
 private:
 	std::shared_ptr<Device> device;
@@ -33,6 +34,8 @@ private:
 	UINT64 timestampBeginValue;
 	UINT64 timestampEndValue;
 	D3D11_QUERY_DATA_TIMESTAMP_DISJOINT timestampDisjointData;
+
+	bool dataFetched = false;
 
 	auto CreateTimestampQuery() -> ComPtr<ID3D11Query>;
 	auto CreateTimestampDisjointQuery() -> ComPtr<ID3D11Query>;

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/splatting-renderer.cpp
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/splatting-renderer.cpp
@@ -84,7 +84,6 @@ auto SplattingRenderer::Render() -> void {
 #endif
 
 	if (settings.enableGPUSynchronization) {
-		createInfo.device->GetRawDeviceContext()->Flush();
 		createInfo.device->GetRawDeviceContext()->End(query.Get());
 
 		// busy wait until the query is done

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/splatting-renderer.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/splatting-renderer.h
@@ -47,6 +47,8 @@ public:
 		float albedoDownsampling = 0.0f;
 		float surfaceFiltering = 0.0f;
 		float rawNormalEstimation = 0.0f;
+
+		bool isDisjoint = false;
 	};
 
 	struct Settings {
@@ -123,6 +125,8 @@ private:
 		util::GPUDuration surfaceFiltering;
 		util::GPUDuration rawNormalEstimation;
 	} durations;
+
+	Timings latestTimings;
 
 	auto CreatePipelines() -> void;
 	auto CreatePipelineInfo() const -> PipelineInfo;

--- a/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/splatting-renderer.h
+++ b/packages/gelly/modules/gelly-fluid-renderer/src/v2/renderers/splatting/splatting-renderer.h
@@ -5,6 +5,7 @@
 #include "GellyInterfaceRef.h"
 #include "device.h"
 #include "fluidsim/ISimData.h"
+#include "helpers/rendering/gpu-duration.h"
 #include "pipeline/pipeline.h"
 #include "pipelines/pipeline-info.h"
 #include "renderdoc_app.h"
@@ -38,6 +39,16 @@ class SplattingRenderer {
 public:
 	float ALBEDO_OUTPUT_SCALE = 0.25f;
 
+	/**
+	 * Timings of all the passes in milliseconds.
+	 */
+	struct Timings {
+		float ellipsoidSplatting = 0.0f;
+		float albedoDownsampling = 0.0f;
+		float surfaceFiltering = 0.0f;
+		float rawNormalEstimation = 0.0f;
+	};
+
 	struct Settings {
 		unsigned int filterIterations = 5;
 		/**
@@ -49,6 +60,14 @@ public:
 		 */
 		bool enableGPUSynchronization = true;
 		bool enableSurfaceFiltering = true;
+		/**
+		 * Should never be true for general use, but this is useful for
+		 * debugging on a user's machine. This will enable the GPU timing
+		 * queries, which will allow for coarse-grained GPU timing information
+		 * to be captured. It is way more in-depth than a simple CPU timing, way
+		 * less than a GPU profiler.
+		 */
+		bool enableGPUTiming = false;
 	};
 
 	struct SplattingRendererCreateInfo {
@@ -72,6 +91,8 @@ public:
 	auto SetFrameResolution(float width, float height) -> void;
 	auto GetSettings() const -> Settings;
 	auto UpdateSettings(const Settings &settings) -> void;
+	auto FetchTimings() -> Timings;
+
 	[[nodiscard]] auto GetAbsorptionModifier() const
 		-> std::shared_ptr<AbsorptionModifier>;
 
@@ -95,6 +116,13 @@ private:
 #ifdef GELLY_ENABLE_RENDERDOC_CAPTURES
 	RENDERDOC_API_1_1_2 *renderDoc = nullptr;
 #endif
+
+	struct {
+		util::GPUDuration ellipsoidSplatting;
+		util::GPUDuration albedoDownsampling;
+		util::GPUDuration surfaceFiltering;
+		util::GPUDuration rawNormalEstimation;
+	} durations;
 
 	auto CreatePipelines() -> void;
 	auto CreatePipelineInfo() const -> PipelineInfo;


### PR DESCRIPTION
## Ticket

<!-- The "Resolves" keyword will automatically close the issue when the PR is merged. -->
Resolves #89 

## Changes

- Adds `GPUDuration` to enable timings
- Exposes timings to GMod
- Perf debugger now prints out timings and extra information

