### PR TITLE
Toggle emitter on use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.28.1] - 2024-10-29
+
+### Changed
+
+- Disc emitters now toggle their emission when used (when you press E and look at one)
+
 ## [1.28.0] - 2024-10-26
 
 ### Added

--- a/packages/addon/lua/entities/gelly_disc_emitter.lua
+++ b/packages/addon/lua/entities/gelly_disc_emitter.lua
@@ -87,3 +87,7 @@ function ENT:Think()
 	self:SetNextClientThink(CurTime() + 0.01)
 	return true
 end
+
+function ENT:Use()
+	self:SetEnabled(not self:GetEnabled())
+end


### PR DESCRIPTION
## Ticket

Resolves nothing

## Changes

- Added an `ENT:Use()` function that toggles the emitter at the end of gelly_disc_emitter.lua

