### PR TITLE
NONE - Improve filter on small projected particle sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.34.1] - 2025-02-11
+
+### Fixed
+
+- Fixed fluid disappearing into pixely bits when viewed afar.
+- Fluid should remain consistent from all distances now. It is significantly harder to assure this for low-radius
+  fluids, but it is apparent for high-radius fluids.
+
 ## [1.34.0] - 2025-02-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed fluid disappearing into pixely bits when viewed afar.
+- Fixed fluid disappearing into pixely bits when viewed afar. Holes may still appear, but they shouldn't be as bad as
+  before this update.
 - Fluid should remain consistent from all distances now. It is significantly harder to assure this for low-radius
   fluids, but it is apparent for high-radius fluids.
 

--- a/packages/gelly-gmod/src/shaders/Composite.ps30.hlsl
+++ b/packages/gelly-gmod/src/shaders/Composite.ps30.hlsl
@@ -48,8 +48,10 @@ float2 whitewaterSettings : register(c27);
 
 struct PS_OUTPUT {
     float4 Color : SV_TARGET0;
-    float Depth : SV_DEPTH;
+    precise float Depth : SV_DEPTH;
 };
+
+static const float GELLY_DEPTH_BIAS = 0.000005f;
 
 float3 WorldPosFromDepth(in float2 tex, in float depth) {
 	float4 pos = float4(tex.x * 2.0f - 1.0f, (1.0f - tex.y) * 2.0f - 1.0f, depth, 1.0f);
@@ -198,6 +200,6 @@ PS_OUTPUT main(VS_INPUT input) {
     
     PS_OUTPUT output = (PS_OUTPUT)0;
     output.Color = Shade(input, depthFragment.r);
-    output.Depth = depthFragment.r;
+    output.Depth = depthFragment.r - GELLY_DEPTH_BIAS;
     return output;
 }


### PR DESCRIPTION
## Ticket

<!-- The "Resolves" keyword will automatically close the issue when the PR is merged. -->
Resolves <!-- ticket number -->

## Changes

- Forces the filter to compensate by reducing sample spread when a particle is estimated to be far away

