### PR TITLE
NONE - Fix D3D device offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.36.3] - 2025-05-12
+
+### Fixed
+
+- Fixed Gelly not working at all because of a recent GMod update.
+
 ## [1.36.2] - 2025-02-15
 
 ### Fixed

--- a/packages/gelly-gmod/src/source/D3DDeviceWrapper.cpp
+++ b/packages/gelly-gmod/src/source/D3DDeviceWrapper.cpp
@@ -19,7 +19,7 @@ void EnsureShaderAPILoaded() {
 /**
  * Current offset to D3DDevice in GMod.
  */
-const uintptr_t D3DDeviceWrapperOffset = 0x9A9D8;
+const uintptr_t D3DDeviceWrapperOffset = 0x9A9C8;
 IDirect3DDevice9Ex *GetD3DDevice() {
 	LOG_INFO("Starting process to get D3D9Ex device.");
 	// Grab the BaseShaderAPIDLL module.


### PR DESCRIPTION
## Ticket

<!-- The "Resolves" keyword will automatically close the issue when the PR is merged. -->
Resolves <!-- ticket number -->

## Changes

- Fixes the D3D device offset which caused a crash.

This is a temporary stopgap, and we'll add a robust solution soon.

