### PR TITLE
58 - Add struct scanning to improve D3D device finding reliability

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,16 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/packages/gelly-gmod/vendor/BSPParser" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/packages/gelly-gmod/vendor/GMFS" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/packages/gelly-gmod/vendor/PHYParser" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/packages/gelly-gmod/vendor/VDFParser" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/packages/gelly-gmod/vendor/gmod-module-base" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/packages/gelly-gmod/vendor/minhook" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/packages/gelly-gmod/vendor/tracy" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/packages/gelly/modules/gelly-fluid-renderer/vendor/renderdoc" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/packages/gelly/modules/gelly-fluid-renderer/vendor/tracy" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/packages/gelly/modules/gelly-fluid-sim/vendor/DirectXMath" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/packages/gelly/modules/gelly-fluid-sim/vendor/FleX" vcs="Git" />
   </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.36.4] - 2025-05-20
+
+### Added
+
+- Added a new way of finding the D3D device, which should fix the issue of Gelly not loading on every GMod update that
+  happens to mess with the offsets.
+
+### Fixed
+
+- Fixed Gelly not loading on the recent hidden GMod update.
+
 ## [1.36.3] - 2025-05-12
 
 ### Fixed

--- a/packages/gelly-gmod/src/main.cpp
+++ b/packages/gelly-gmod/src/main.cpp
@@ -1072,16 +1072,22 @@ extern "C" __declspec(dllexport) int gmod13_open(lua_State *L) {
 	GetClientViewSetup(currentView);
 
 	if (!GetD3DDevice()) {
+		LOG_ERROR("Failed to fetch D3D device!");
 		LUA->ThrowError(
+			"\nGELLY FATAL ERROR: Failed to fetch D3D device!\n"
+			"----------------------------------------------\n"
+			"This could be due to a number of reasons, including:\n"
 			"Gelly has detected that the current GMod instance is running "
-			"in "
-			"DirectX 9 mode. Gelly requires Direct3D9Ex to function. Check "
+			"in"
+			"DirectX 9 mode. Gelly requires Direct3D9Ex to function.\nCheck "
 			"if "
 			"you have any launch options that force DirectX 9 mode--such "
 			"as "
-			"'-nod3d9ex' "
+			"'-nod3d9ex'\n"
 			"Certain optimization configs/mods might also force DirectX 9 "
-			"mode. "
+			"mode.\n"
+			"OR\n"
+			"Gelly is out of date and needs to be updated.\n"
 		);
 	}
 

--- a/packages/gelly-gmod/src/source/D3DDeviceWrapper.cpp
+++ b/packages/gelly-gmod/src/source/D3DDeviceWrapper.cpp
@@ -19,22 +19,81 @@ void EnsureShaderAPILoaded() {
 /**
  * Current offset to D3DDevice in GMod.
  */
-const uintptr_t D3DDeviceWrapperOffset = 0x9A9C8;
+const uintptr_t D3DDeviceWrapperStructStart = 0x98000;
+const uintptr_t D3DDeviceWrapperStructSize = 0x4000;
+const uintptr_t D3DDeviceWrapperOffset = 0x9a928;
+
 IDirect3DDevice9Ex *GetD3DDevice() {
 	LOG_INFO("Starting process to get D3D9Ex device.");
 	// Grab the BaseShaderAPIDLL module.
 	EnsureShaderAPILoaded();
 
-	const auto *d3dDeviceWrapper =
-		shaderAPI.GetObjectAt<D3DDeviceWrapper *>(D3DDeviceWrapperOffset);
+	// Try struct scanning first, if that fails, try the offset.
+	LOG_INFO("Starting with a struct scan...");
+	auto *d3dDeviceWrapper = reinterpret_cast<D3DDeviceWrapper *>(nullptr);
+
+	const auto structAddress = shaderAPI.ScanStruct({
+		.start = D3DDeviceWrapperStructStart,
+		.size = D3DDeviceWrapperStructSize,
+		.target =
+			{
+				.members =
+					{{
+						 // Pointer to IDirect3DDevice9
+						 .offset = 0x0,
+						 .size = sizeof(IDirect3DDevice9 *),
+						 .predicate =
+							 [](const void *data, size_t) {
+								 uintptr_t address =
+									 *static_cast<const uintptr_t *>(data);
+								 return address != 0 && address != 0xFFFFFFFF &&
+										address > 0x1000;
+							 },
+					 },
+					 {
+						 // Single 0x01 byte (not sure what it is, but its
+						 // there)
+						 .offset = sizeof(IDirect3DDevice9 *),
+						 .size = 1,	 // single byte
+						 .predicate =
+							 [](const void *data, size_t) {
+								 return *static_cast<const uint8_t *>(data) ==
+										0x01;
+							 },
+					 },
+					 {
+						 // 15 bytes of padding
+						 .offset = sizeof(IDirect3DDevice9 *) + 1,
+						 .size = 15,
+						 .predicate = AlwaysNull,
+					 },
+					 {
+						 // 0x07 byte
+						 .offset = sizeof(IDirect3DDevice9 *) + 15 + 1,
+						 .size = 1,
+						 .predicate =
+							 [](const void *data, size_t) {
+								 return *static_cast<const uint8_t *>(data) ==
+										0x07;
+							 },
+					 }},
+			},
+	});
+
+	d3dDeviceWrapper = reinterpret_cast<D3DDeviceWrapper *>(structAddress);
 
 	if (!d3dDeviceWrapper) {
-		LOG_WARNING("Bailing: D3DDeviceWrapper is null.");
-		return nullptr;
+		LOG_WARNING("Struct scan failed... trying offset scan.");
+		d3dDeviceWrapper =
+			shaderAPI.GetObjectAt<D3DDeviceWrapper *>(D3DDeviceWrapperOffset);
 	}
 
 	LOG_INFO("Fetched D3DDevice wrapper at address: %p", d3dDeviceWrapper);
 	IDirect3DDevice9 *d3d9Device = d3dDeviceWrapper->m_pD3DDevice;
+	if (!d3d9Device) {
+		LOG_WARNING("Bailing: D3D9 device is null.");
+		return nullptr;
+	}
 
 	// So, GMod like most source games automatically use D3D9Ex. This is great
 	// because Gelly's texture interop will *only* work on D3D9Ex. However, the
@@ -44,6 +103,12 @@ IDirect3DDevice9Ex *GetD3DDevice() {
 	// The major thing about this though is that this functions as a check if
 	// the device is D3D9Ex. If it isn't, then we can't use Gelly's texture
 	// interop and thus Gelly will refuse to load.
+
+	uintptr_t vtableAddress = *reinterpret_cast<uintptr_t *>(d3d9Device);
+	if (!vtableAddress) {
+		LOG_WARNING("Bailing: D3D9 device vtable is null.");
+		return nullptr;
+	}
 
 	IDirect3DDevice9Ex *d3d9DeviceEx = nullptr;
 	HRESULT result = d3d9Device->QueryInterface(IID_PPV_ARGS(&d3d9DeviceEx));


### PR DESCRIPTION
## Ticket

<!-- The "Resolves" keyword will automatically close the issue when the PR is merged. -->
Resolves #58 

## Changes

- Adds struct scanning to `Library`, which means Gelly will now scan for the D3DDeviceWrapper structure before using the offset.

It currently scans for a range near the current and past offsets, about 16kb large. It's fairly fast but it will fall back to the offset if nothing comes up in the struct scan.

